### PR TITLE
Check if `adb` command exists before using the inbuilt one

### DIFF
--- a/root.sh
+++ b/root.sh
@@ -2,10 +2,10 @@
 set -e
 
 HERE=$(cd "$(dirname "$0")" && pwd)
-if [ -x "$HERE/bin/linux/adb" ]; then
-  ADB="$HERE/bin/linux/adb"
-else
+if command -v adb >/dev/null 2>&1; then
   ADB=adb
+else
+  ADB="$HERE/bin/linux/adb"
 fi
 if [ -f "$HERE/bin/preload" ]; then
   DEFAULT_PRELOAD="$HERE/bin/preload"


### PR DESCRIPTION
It may sound strange, but you can run this exploit via Termux with ADB Wireless, and it works quite reliably as well :D.

Tested on karat running FireOS 8.1.8.0

Change-Id: I44cda3fd05ef33e6c79eb6943daf67694b2bfea0